### PR TITLE
Remove leading space from keywords.txt identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#####0.0.9
+- Fixed keywords definitions for highlighting in the Arduino IDE
+
 #####0.0.8
 - Readme updates
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -2,11 +2,11 @@
 # Syntax coloring Map for lib_bl999
 #####################################
 
-BL999Info               KEYWORD1
-bl999_set_rx_pin        KEYWORD2
-bl999_rx_start          KEYWORD2
-bl999_rx_stop           KEYWORD2
-bl999_wait_rx           KEYWORD2
-bl999_wait_rx_max       KEYWORD2
-bl999_have_message      KEYWORD2
-bl999_get_message       KEYWORD2
+BL999Info	KEYWORD1
+bl999_set_rx_pin	KEYWORD2
+bl999_rx_start	KEYWORD2
+bl999_rx_stop	KEYWORD2
+bl999_wait_rx	KEYWORD2
+bl999_wait_rx_max	KEYWORD2
+bl999_have_message	KEYWORD2
+bl999_get_message	KEYWORD2

--- a/library.json
+++ b/library.json
@@ -9,5 +9,5 @@
   },
   "frameworks": "arduino",
   "platforms": ["atmelavr", "espressif"],
-  "version": "0.0.8"
+  "version": "0.0.9"
 }


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords